### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/fastcampus/boardproject/domain/Article.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/Article.java
@@ -51,12 +51,12 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && this.id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/boardproject/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/ArticleComment.java
@@ -41,11 +41,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
@@ -43,12 +43,12 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
엔티티의 equals(), hashcode()가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #41