### PR TITLE
헤로쿠에 배포하기 - gradle.properties 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ tasks.named('test') {
 }
 
 // Querydsl 설정부
-def generated = "/src/main/generated"
+def generated = "src/main/generated"
 
 // querydsl QClass 파일 생성 위치
 tasks.withType(JavaCompile) {
@@ -73,6 +73,6 @@ clean {
 // Heroku 설정
 jar {
     manifest {
-        attributes('Main-Class': 'com.fastcampus.boardproject.FastcampusBoardProjectApplication')
+        attributes('Main-Class': 'com.fastcampus.boardproject.FastCampusBoardProjectApplication')
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false


### PR DESCRIPTION
Gradle 관련 설정 파일을 추가하여
데몬이 여러 개로 작동되지 않도록 설정함.

This fixes #85

- https://docs.gradle.org/7.6/userguide/gradle_daemon.html#sec:disabling_the_daemon