### PR TITLE
헤로쿠 무료 배포 중단으로 인한 데모 페이지 변경됨.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,14 @@ Spring Boot
 
 * QueryDSL 5.0.0
 * Bootstrap 5.2.3
-* Heroku
+* ~~Heroku~~
+* CloudType
 
 ## 데모 페이지
 
-* https://board-project-test.herokuapp.com/
+* ~~https://board-project-test.herokuapp.com~~
+* <https://port-0-fastcampus-board-project-nx562olfuhiak2.sel3.cloudtype.app>
 
 ## Reference
+* 유즈케이스 다이어그램: #4,
+<https://viewer.diagrams.net/?tags=%7B%7D&highlight=0000ff&edit=_blank&layers=1&nav=1&title=use-case.svg#Uhttps%3A%2F%2Fraw.githubusercontent.com%2FSwacker3927%2Ffastcampus-board-project%2Fmain%2Fdocument%2Fuse-case.svg>


### PR DESCRIPTION
- [https://blog.heroku.com/next-chapter](https://blog.heroku.com/next-chapter)

위 블로그 링크 내 내용에 의하면,
2022년 11월 28일부터 무료 제품 플랜 제공을 중단하고 무료 dynos 및 데이터 서비스를 종료할 계획이라고 한다.

해당 헤로쿠 앱을 유지보수 모드로 'On'하여 추가 비용이 나가지 못 하게 막았고,
대체재인 CloudType에서 새로 배포하였다.

그 외, 유즈케이스 링크도 추가했다.

This fixes #90