### PR TITLE
API 호출이 가능하도록 인증 설정 변경하기

### DIFF
--- a/src/main/java/com/fastcampus/boardproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/boardproject/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers("/api/**").permitAll()
                         .mvcMatchers(
                                 HttpMethod.GET,
                                 "/",
@@ -47,6 +48,7 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService)
                         )
                 )
+                .csrf(csrf -> csrf.ignoringAntMatchers("/api/**"))
                 .build();
     }
 
@@ -57,6 +59,7 @@ public class SecurityConfig {
                 .map(BoardPrincipal::from)
                 .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다. - username: " + username));
     }
+
     /**
      * <p>
      * OAuth 2.0 기술을 이용한 인증 정보를 처리한다.
@@ -65,8 +68,8 @@ public class SecurityConfig {
      * <p>
      * TODO: 카카오 도메인에 결합되어 있는 코드. 확장을 고려하면 별도 인증 처리 서비스 클래스로 분리하는 것이 좋지만, 현재 다른 OAuth 인증 플랫폼을 사용할 예정이 없어 이렇게 마무리한다.
      *
-     * @param userAccountService  게시판 서비스의 사용자 계정을 다루는 서비스 로직
-     * @param passwordEncoder 패스워드 암호화 도구
+     * @param userAccountService 게시판 서비스의 사용자 계정을 다루는 서비스 로직
+     * @param passwordEncoder    패스워드 암호화 도구
      * @return {@link OAuth2UserService} OAuth2 인증 사용자 정보를 읽어들이고 처리하는 서비스 인스턴스 반환
      */
     @Bean


### PR DESCRIPTION
이 PR은 외부 서비스에서 원활하게 게시판 서비스의 데이터 API를 이용할 수 있도록 시큐리티 설정을 업데이트 한다.

This closes #93 